### PR TITLE
Add a context menu to create classes at specific places

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Make Pull Request when you have feature ideas & if you want, support me by spons
 
 ### Changelog
 
+- Added context menu class creation
 - Added Header Protection settings
 - little refactorings
 - removed experimental settings

--- a/package.json
+++ b/package.json
@@ -25,6 +25,14 @@
 				"command": "extension.createClass"
 			}
 		],
+		"menus": {
+			"explorer/context": [
+				{
+					"group": "navigation@-1",
+					"command": "extension.createClass"
+				}
+			]
+		},
 		"keybindings": [
 			{
 				"command": "extension.createClass",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import * as fs from 'fs';
+import * as path from 'path';
 
 
 async function create_name_input()
@@ -180,15 +181,24 @@ export async function activate(context: vscode.ExtensionContext) {
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "cpp-class-creator" is now active!');
 
-	let disposable = vscode.commands.registerCommand('extension.createClass', async () => {
+	let disposable = vscode.commands.registerCommand('extension.createClass', async (args) => {
 		// The code you place here will be executed every time your command is executed
 
 		var res = await create_name_input();
 			if(!can_continue(res)) return; // check for class name
 
 			let dir :string | undefined | boolean= vscode.workspace.getConfiguration().get("cpp.creator.setPath");
-		//	if (dir == false)
-		//		dir = null as any; // stupid parsing
+			// If it's called via the context menu, it's gonna have the _fsPath set from where you're clicking
+			if (args != null && args._fsPath != null) {
+				dir = args._fsPath;
+				if (typeof dir === "string" && fs.existsSync(dir)) {
+					var stats = fs.lstatSync(dir);
+					if (!stats.isDirectory()) {
+						//If it's not a directory then it's the file so get the parent directory
+						dir = path.dirname(args._fsPath);
+					}
+				}
+			}
 			if (dir == null || dir == false) {
 				dir = vscode.workspace.rootPath as string; // use workspace path
 				let createFolder: boolean | undefined = vscode.workspace.getConfiguration().get("cpp.creator.createFolder");


### PR DESCRIPTION
### Summary:
To make it faster to create classes in specific folders this patch adds a context menu entry to create a class from the explorer.

You can use it on a folder to create it there or on a file to create it on a parent folder.

### Test case:
First case:
- Right click a folder in the explorer
- Enter a class name
- The files should be created in this folder

Second case:
- Right click a file in the explorer
- Enter a class name
- The files should be created in the parent folder of the file

Third case:
- Use the keyboard shortcut
- It should use your directory settings to save the files