### PR TITLE
Added date and time commands to file name and content presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ For file name presets:
 - CLASSNAMELOWER - default classname to lower
 - CLASSNAMECAPI  - default classname with capitalized first letter
 - CLASSNAME      - default classname
+- CURRENTDATETIME - current date and time
+- CURRENTDATE    - current date
+- CURRENTTIME    - current time
 
 For file content presets:
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ For file content presets:
 - CLASSNAMELOWER - default classname to lower
 - CLASSNAMECAPI  - default classname with capitalized first letter
 - CLASSNAME      - default classname
+- CURRENTDATETIME - current date and time
+- CURRENTDATE    - current date
+- CURRENTTIME    - current time
 
 
 ## Features

--- a/src/class_creator.ts
+++ b/src/class_creator.ts
@@ -34,6 +34,9 @@ export class class_creator
         var default_regex           : RegExp = /{{\*CLASSNAME\*}}/gi;
         var headerfilename_regex    : RegExp = /{{\*HEADERFILENAME\*}}/gi;
         var sourcefilename_regex    : RegExp = /{{\*SOURCEFILENAME\*}}/gi;
+        var datetime_regex          : RegExp = /{{\*CURRENTDATETIME\*}}/gi;
+        var date_regex              : RegExp = /{{\*CURRENTDATE\*}}/gi;
+        var time_regex              : RegExp = /{{\*CURRENTTIME\*}}/gi;
 
         const file_cmds: Array<command_replace_model> = [
             { reg_expression: upper_regex, replace_string: regex_commands.upper_case(this.class_name)},// CLASSNAMEUPPER - default classname to upper
@@ -49,6 +52,10 @@ export class class_creator
             { reg_expression: lower_regex, replace_string: regex_commands.lower_case(this.class_name)},      // CLASSNAMELOWER - default classname to lower
             { reg_expression: cap_regex, replace_string: regex_commands.capitalize(this.class_name)},        // CLASSNAMECAPI  - default classname with capitalized first letter
             { reg_expression: default_regex, replace_string: regex_commands.default(this.class_name)},       // CLASSNAME      - default classname
+            { reg_expression: datetime_regex, replace_string: regex_commands.current_date_time()},      // CURRENTDATETIME  - the current date and time
+            { reg_expression: date_regex, replace_string: regex_commands.current_date()},               // CURRENTDATE      - the current date
+            { reg_expression: time_regex, replace_string: regex_commands.current_time()},               // CURRENTTIME      - the current time
+            
         ]
 
         this.source_file = this.execute_replacement(file_cmds, this.source_file);

--- a/src/class_creator.ts
+++ b/src/class_creator.ts
@@ -43,6 +43,9 @@ export class class_creator
             { reg_expression: lower_regex, replace_string: regex_commands.lower_case(this.class_name)},// CLASSNAMELOWER - default classname to lower
             { reg_expression: cap_regex, replace_string: regex_commands.capitalize(this.class_name)},  // CLASSNAMECAPI  - default classname with capitalized first letter
             { reg_expression: default_regex, replace_string: regex_commands.default(this.class_name)}, // CLASSNAME      - default classname
+            { reg_expression: datetime_regex, replace_string: regex_commands.current_date_time()},      // CURRENTDATETIME  - the current date and time
+            { reg_expression: date_regex, replace_string: regex_commands.current_date()},               // CURRENTDATE      - the current date
+            { reg_expression: time_regex, replace_string: regex_commands.current_time()},               // CURRENTTIME      - the current time
         ]
 
         const content_cmds: Array<command_replace_model> = [

--- a/src/regex_commands.ts
+++ b/src/regex_commands.ts
@@ -29,4 +29,24 @@ export abstract class regex_commands
     {
         return s_file;
     }
+
+    public static current_date() : string
+    {
+        let dateTime = new Date();
+        let date = dateTime.getDate();
+        return dateTime.toLocaleDateString();
+    }
+
+    public static current_time() : string
+    {
+        let dateTime = new Date();
+        let time = dateTime.getTime();
+        return dateTime.toLocaleTimeString();
+    }
+
+    public static current_date_time() : string
+    {
+        let dateTime = new Date();
+        return dateTime.toLocaleString();
+    }
 }


### PR DESCRIPTION
Following from the issue [27](https://github.com/tzAcee/cpp-class-creator/issues/27).
I have added three new file content/file name presets:
CURRENTDATE - replaces with the current date
CURRENTTIME - replaces with the current time
CURRENTDATETIME - replaces with the current date and time